### PR TITLE
Refactor GameBoard to receive derived board from turns and update tets accordingly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Header from "./components/Header";
 import Player from "./components/Player";
 import GameBoard from "./components/GameBoard";
 import type { Turns } from "./types/game";
-import { initialBoardState } from "./Utils/GameBoardUtils";
+import { deriveGameBoard } from "./Utils/GameBoardUtils";
 
 const players = {
   X: "Player 1",
@@ -11,10 +11,12 @@ const players = {
 };
 
 const App = () => {
-  let gameBoard = initialBoardState;
   const [playersName, setPlayersName] = useState(players);
   const [currentPlayer, setCurrenttPlayer] = useState<"X" | "O">("X");
   const [turns, setTurns] = useState<Turns[]>([]);
+
+  const board = deriveGameBoard(turns);
+
   const handleNameChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     symbol: "X" | "O"
@@ -27,14 +29,14 @@ const App = () => {
     }));
   };
   const handleTurn = (rowIndex: number, colIndex: number) => {
-    if (gameBoard[rowIndex][colIndex] !== null) {
+    if (board[rowIndex][colIndex] !== null) {
       return;
     }
     setTurns((prev) => [
       { square: { rowIndex, colIndex }, player: currentPlayer },
       ...prev,
     ]);
-    console.log(turns);
+
     switchPlayer();
   };
   const switchPlayer = () => {
@@ -59,7 +61,7 @@ const App = () => {
             isActive={currentPlayer === "O"}
           />
         </ol>
-        <GameBoard turns={turns} handleTurn={handleTurn} />
+        <GameBoard handleTurn={handleTurn} board={board} />
       </div>
     </main>
   );

--- a/src/Utils/GameBoardUtils.ts
+++ b/src/Utils/GameBoardUtils.ts
@@ -1,6 +1,20 @@
-import type { gameBoardMatrix } from "../types/game";
+import type { gameBoardMatrix, Turns } from "../types/game";
 export const initialBoardState: gameBoardMatrix = [
   [null, null, null],
   [null, null, null],
   [null, null, null],
 ];
+export const deriveGameBoard = (turns: Turns[]) => {
+  // Create a deep copy of the board so we don't accidentally modify the original
+  // - map goes through each row in the board
+  // - [...row] makes a shallow copy of each row (so we copy values, not references)
+  // - TypeScript forgets it's a fixed 3x3 tuple at this point
+  // - so we use 'as gameBoardMatrix' to assert the correct type and avoid errors
+  let gameBoard = initialBoardState.map((row) => [...row]) as gameBoardMatrix;
+  for (const turn of turns) {
+    const { square, player }: Turns = turn;
+    const { rowIndex, colIndex } = square;
+    gameBoard[rowIndex][colIndex] = player;
+  }
+  return gameBoard;
+};

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,26 +1,17 @@
-import type { Turns } from "../types/game";
-import { initialBoardState } from "../Utils/GameBoardUtils";
+import { gameBoardMatrix } from "../types/game";
 
 // Define the expected props for the GameBoard component
 // Ensures type safety and clarity when using the component, helping to avoid type errors
 
 type GameBoardProps = {
-  turns: Turns[];
+  board: gameBoardMatrix;
   handleTurn: (rowIndex: number, colIndex: number) => void;
 };
 
-const GameBoard = ({ turns, handleTurn }: GameBoardProps) => {
-  let gameBoard = [...initialBoardState];
-
-  for (const turn of turns) {
-    const { square, player }: Turns = turn;
-    const { rowIndex, colIndex } = square;
-    gameBoard[rowIndex][colIndex] = player;
-  }
-
+const GameBoard = ({ handleTurn, board }: GameBoardProps) => {
   return (
     <ol id="game-board">
-      {gameBoard.map((row, rowIndex) => (
+      {board.map((row, rowIndex) => (
         <ol key={rowIndex}>
           {row.map((symbol, colIndex) => (
             <li key={colIndex}>

--- a/src/tests/__tests__/gameBoard.test.tsx
+++ b/src/tests/__tests__/gameBoard.test.tsx
@@ -1,15 +1,15 @@
 import { screen, render } from "@testing-library/react";
 import GameBoard from "../../components/GameBoard";
-import type { Turns } from "../../types/game";
 import userEvent from "@testing-library/user-event";
+import { deriveGameBoard } from "../../Utils/GameBoardUtils";
 
 const mockHandleTurn = vi.fn();
 const user = userEvent.setup();
 describe("gameBoard component tests", () => {
   beforeEach(() => {
     // turns bust be defined in each describe block to avoid all test using same values
-    let turns: Turns[] = [];
-    render(<GameBoard turns={turns} handleTurn={mockHandleTurn} />);
+    let mockBoard = deriveGameBoard([]);
+    render(<GameBoard board={mockBoard} handleTurn={mockHandleTurn} />);
   });
 
   test("component renders with blank gameboard containing 9 buttons", () => {
@@ -29,11 +29,12 @@ describe("gameBoard component tests", () => {
 
 describe("game board populate correctly", () => {
   // turns bust be defined in each describe block to avoid all test using same values
-  let turns: Turns[] = [];
 
   beforeEach(() => {
-    turns = [{ square: { rowIndex: 0, colIndex: 0 }, player: "X" }];
-    render(<GameBoard turns={turns} handleTurn={mockHandleTurn} />);
+    let mockBoard = deriveGameBoard([
+      { square: { rowIndex: 0, colIndex: 0 }, player: "X" },
+    ]);
+    render(<GameBoard board={mockBoard} handleTurn={mockHandleTurn} />);
   });
   test("gameboard populates with correct symbol", () => {
     const buttons = screen.getAllByRole("button");


### PR DESCRIPTION
GameBoard now takes a derived board prop instead of turns. Tests were updated to use deriveGameBoard() to generate the board. This keeps turns as the single source of truth and simplifies future logic like winner detection.