### PR TITLE
Add winner and draw logic with tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Header from "./components/Header";
 import Player from "./components/Player";
 import GameBoard from "./components/GameBoard";
 import type { Turns } from "./types/game";
-import { deriveGameBoard } from "./Utils/GameBoardUtils";
+import { deriveGameBoard, deriveWinner } from "./Utils/GameBoardUtils";
 
 const players = {
   X: "Player 1",
@@ -16,6 +16,10 @@ const App = () => {
   const [turns, setTurns] = useState<Turns[]>([]);
 
   const board = deriveGameBoard(turns);
+
+  let winner = deriveWinner(board);
+  const draw = !winner && turns.length === 9;
+  console.log(draw);
 
   const handleNameChange = (
     e: React.ChangeEvent<HTMLInputElement>,

--- a/src/Utils/GameBoardUtils.ts
+++ b/src/Utils/GameBoardUtils.ts
@@ -1,4 +1,5 @@
 import type { gameBoardMatrix, Turns } from "../types/game";
+import { WINNING_COMBINATIONS } from "./winningCombinatopns";
 export const initialBoardState: gameBoardMatrix = [
   [null, null, null],
   [null, null, null],
@@ -17,4 +18,32 @@ export const deriveGameBoard = (turns: Turns[]) => {
     gameBoard[rowIndex][colIndex] = player;
   }
   return gameBoard;
+};
+
+export const deriveWinner = (gameBoard: gameBoardMatrix) => {
+  let winner;
+  for (const [
+    // Destructure each winning combination
+    // (Each combination is an array of three {row, column} objects)
+    { row: r1, column: c1 },
+    { row: r2, column: c2 },
+    { row: r3, column: c3 },
+  ] of WINNING_COMBINATIONS) {
+    // Get the symbols at each of the three winning positions
+    const firstSymbol = gameBoard[r1][c1];
+    const secondSymbol = gameBoard[r2][c2];
+    const thirdSymbol = gameBoard[r3][c3];
+
+    // Check if all three are equal and not null — we have a winner
+    if (
+      firstSymbol != null &&
+      firstSymbol === secondSymbol &&
+      firstSymbol === thirdSymbol
+    ) {
+      winner = firstSymbol;
+      break;
+    }
+  }
+  // if all match return winner
+  return winner;
 };

--- a/src/Utils/winningCombinatopns.ts
+++ b/src/Utils/winningCombinatopns.ts
@@ -1,4 +1,9 @@
-export const WINNING_COMBINATIONS = [
+export type Coordinate = {
+  row: number;
+  column: number;
+};
+
+export const WINNING_COMBINATIONS: Coordinate[][] = [
   [
     { row: 0, column: 0 },
     { row: 0, column: 1 },

--- a/src/tests/__tests__/deriivedWinner.test.ts
+++ b/src/tests/__tests__/deriivedWinner.test.ts
@@ -1,0 +1,29 @@
+import { gameBoardMatrix } from "../../types/game";
+import { deriveWinner } from "../../Utils/GameBoardUtils";
+
+test("detects horizontal win", () => {
+  const board = [
+    ["X", "X", "X"],
+    [null, null, null],
+    [null, null, null],
+  ] as gameBoardMatrix;
+  expect(deriveWinner(board)).toBe("X");
+});
+
+test("detects vertical win", () => {
+  const board = [
+    ["O", null, null],
+    ["O", null, null],
+    ["O", null, null],
+  ] as gameBoardMatrix;
+  expect(deriveWinner(board)).toBe("O");
+});
+
+test("detects diagonal win", () => {
+  const board = [
+    ["O", null, null],
+    [null, "O", null],
+    [null, null, "O"],
+  ] as gameBoardMatrix;
+  expect(deriveWinner(board)).toBe("O");
+});


### PR DESCRIPTION
- Implemented deriveWinner to check for win conditions based on board state
- Added draw logic (based on turn count and absence of winner)
- Created unit tests to verify win scenarios (rows, columns, diagonals)
- Ensured draw is handled in game logic, not within deriveWinner
- Improved comments and code clarity