### PR TITLE
Add full game interaction tests and fix player name display on win

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,6 @@ const App = () => {
   let winner = deriveWinner(board);
 
   const draw = !winner && turns.length === 9;
-  console.log(draw);
 
   const handleNameChange = (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -73,7 +72,7 @@ const App = () => {
         </ol>
         {(winner || draw) && (
           <GameOver
-            winner={winner ? players[winner] : undefined}
+            winner={winner ? playersName[winner] : undefined}
             onRestart={onRestart}
           />
         )}

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -16,6 +16,7 @@ const GameBoard = ({ handleTurn, board }: GameBoardProps) => {
           {row.map((symbol, colIndex) => (
             <li key={colIndex}>
               <button
+                data-testid="square"
                 onClick={() => {
                   handleTurn(rowIndex, colIndex);
                 }}

--- a/src/components/GameOver.tsx
+++ b/src/components/GameOver.tsx
@@ -4,6 +4,7 @@ type gameOverProps = {
 };
 
 export default function GameOver({ winner, onRestart }: gameOverProps) {
+  console.log(winner);
   return (
     <div id="game-over">
       <h2>Game Over!</h2>

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -30,7 +30,7 @@ const Player = ({
     <input
       value={playerName}
       autoFocus
-      name={playerName}
+      name={`${playerName}`}
       onChange={(e) => handleNameChange(e, symbol)}
     />
   );
@@ -40,7 +40,10 @@ const Player = ({
       <span className="player">
         {player}
         <span className="player-symbol">{symbol}</span>
-        <button onClick={() => handleEdit()}>
+        <button
+          data-testid={`playerNameButton-${symbol}`}
+          onClick={() => handleEdit()}
+        >
           {isEditing ? "Save" : "Edit"}
         </button>
       </span>

--- a/src/tests/__tests__/app.test.tsx
+++ b/src/tests/__tests__/app.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../../App";
+import type { UserEvent } from "@testing-library/user-event";
+
+test("complete game flow: rename, play, win, draw, reset", async () => {
+  const user = userEvent.setup();
+  render(<App />);
+
+  // -----------------------------
+  // Step 1: Rename the players
+  // -----------------------------
+  await user.click(screen.getByTestId("playerNameButton-X"));
+  let input = screen.getByRole("textbox");
+  await user.clear(input);
+  await user.type(input, "Alfie");
+  await user.click(screen.getByRole("button", { name: "Save" }));
+
+  await user.click(screen.getByTestId("playerNameButton-O"));
+  input = screen.getByRole("textbox");
+  await user.clear(input);
+  await user.type(input, "Bob");
+  await user.click(screen.getByRole("button", { name: "Save" }));
+
+  expect(screen.getByText("Alfie")).toBeInTheDocument();
+  expect(screen.getByText("Bob")).toBeInTheDocument();
+
+  // -----------------------------
+  // Step 2: Play game until Alfie wins
+  // -----------------------------
+  const squares = screen.getAllByTestId("square");
+  await user.click(squares[0]); // X (Alfie)
+  await user.click(squares[3]); // O (Bob)
+  await user.click(squares[1]); // X (Alfie)
+  await user.click(squares[4]); // O (Bob)
+  await user.click(squares[2]); // X (Alfie)wins
+
+  expect(screen.getByText(/Alfie won!/i)).toBeInTheDocument();
+
+  // -----------------------------
+  // Step 3: Reset and check board is clear
+  // -----------------------------
+  await user.click(screen.getByRole("button", { name: /Rematch!/i }));
+
+  squares.forEach((square) => {
+    expect(square).toHaveTextContent("");
+  });
+
+  // -----------------------------
+  // Step 4: Play a draw round
+  // -----------------------------
+  await user.click(squares[0]); // X
+  await user.click(squares[1]); // O
+  await user.click(squares[2]); // X
+  await user.click(squares[4]); // O
+  await user.click(squares[3]); // X
+  await user.click(squares[5]); // O
+  await user.click(squares[7]); // X
+  await user.click(squares[6]); // O
+  await user.click(squares[8]); // X
+
+  expect(screen.getByText(/It's a draw/i)).toBeInTheDocument();
+});

--- a/src/tests/__tests__/gameBoard.test.tsx
+++ b/src/tests/__tests__/gameBoard.test.tsx
@@ -2,12 +2,14 @@ import { screen, render } from "@testing-library/react";
 import GameBoard from "../../components/GameBoard";
 import userEvent from "@testing-library/user-event";
 import { deriveGameBoard } from "../../Utils/GameBoardUtils";
+import type { UserEvent } from "@testing-library/user-event";
 
 const mockHandleTurn = vi.fn();
-const user = userEvent.setup();
+let user: UserEvent;
 describe("gameBoard component tests", () => {
   beforeEach(() => {
     // turns bust be defined in each describe block to avoid all test using same values
+    user = userEvent.setup();
     let mockBoard = deriveGameBoard([]);
     render(<GameBoard board={mockBoard} handleTurn={mockHandleTurn} />);
   });

--- a/src/tests/__tests__/gameOver.test.tsx
+++ b/src/tests/__tests__/gameOver.test.tsx
@@ -1,10 +1,11 @@
 import { screen, render } from "@testing-library/react";
 import GameOver from "../../components/GameOver";
 import userEvent from "@testing-library/user-event";
-
+import type { UserEvent } from "@testing-library/user-event";
+let user: UserEvent;
 describe("winner name is displayeds", () => {
   const mockRestart = vi.fn();
-  const user = userEvent.setup();
+  user = userEvent.setup();
   test("winner is display if player symbol received", () => {
     render(<GameOver winner="Player 1" onRestart={mockRestart} />);
     const winner = screen.getByText(/Player 1 won!/i);

--- a/src/tests/__tests__/player.test.tsx
+++ b/src/tests/__tests__/player.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 import Player from "../../components/Player";
 import PlayerWrapper from "../testWrappers/PlayerWrapper";
-const user = userEvent.setup();
+import type { UserEvent } from "@testing-library/user-event";
+
 let mockPlayers = {
   X: "Player 1",
   O: "Player 2",
 };
-
+let user: UserEvent;
 const mockNameChange = vi.fn();
 const componentUnderTest = (
   <Player
@@ -20,7 +21,9 @@ const componentUnderTest = (
 
 describe("player component renders correctly", () => {
   // added so that state changes can be checked
+
   beforeEach(() => {
+    user = userEvent.setup();
     render(componentUnderTest);
   });
 
@@ -68,7 +71,6 @@ describe("player element class", () => {
         isActive={false}
       />
     );
-    screen.debug();
     const playerElement = screen.getByRole("listitem");
     expect(playerElement).not.toHaveClass("active");
   });
@@ -78,6 +80,7 @@ describe("Player input interactions (with wrapper)", async () => {
   const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
 
   beforeEach(() => {
+    user = userEvent.setup();
     alertMock;
     render(<PlayerWrapper />);
   });


### PR DESCRIPTION
- Reworked `App.tsx` to ensure dynamic player names persist throughout
- Fixed winner display logic to reference updated player names
- Combined all integration tests into a single render flow for realism
- Verified draw and win conditions, board reset, and name editing