### PR TITLE
feat(player): validate player names, disable board, and save on Enter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ const App = () => {
   const [playersName, setPlayersName] = useState(players);
   const [currentPlayer, setCurrenttPlayer] = useState<"X" | "O">("X");
   const [turns, setTurns] = useState<Turns[]>([]);
+  const [playerNameError, setPlayersNameError] = useState({ X: "", O: "" });
+  const [isValid, setIsValid] = useState(true);
 
   const board = deriveGameBoard(turns);
 
@@ -27,11 +29,26 @@ const App = () => {
     symbol: "X" | "O"
   ) => {
     const newInput = e.target.value;
+    const trimmed = newInput.trim();
+    const otherSymbol = symbol === "X" ? "O" : "X";
 
-    setPlayersName((prev) => ({
-      ...prev,
-      [symbol]: newInput,
-    }));
+    setPlayersName((prev) => ({ ...prev, [symbol]: newInput }));
+    if (!trimmed) {
+      setPlayersNameError((prev) => ({
+        ...prev,
+        [symbol]: "Player name can not be blank",
+      }));
+      setIsValid(false);
+    } else if (trimmed === playersName[otherSymbol].trim()) {
+      setPlayersNameError((prev) => ({
+        ...prev,
+        [symbol]: "Player name must be unique",
+      }));
+      setIsValid(false);
+    } else {
+      setPlayersNameError((prev) => ({ ...prev, [symbol]: "" }));
+      setIsValid(true);
+    }
   };
   const handleTurn = (rowIndex: number, colIndex: number) => {
     if (board[rowIndex][colIndex] !== null) {
@@ -61,12 +78,14 @@ const App = () => {
             playerName={playersName.X}
             symbol="X"
             handleNameChange={handleNameChange}
+            playerNameError={playerNameError.X}
             isActive={currentPlayer === "X"}
           />
           <Player
             playerName={playersName.O}
             symbol="O"
             handleNameChange={handleNameChange}
+            playerNameError={playerNameError.O}
             isActive={currentPlayer === "O"}
           />
         </ol>
@@ -76,7 +95,7 @@ const App = () => {
             onRestart={onRestart}
           />
         )}
-        <GameBoard handleTurn={handleTurn} board={board} />
+        <GameBoard handleTurn={handleTurn} board={board} isValid={isValid} />
       </div>
     </main>
   );

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -6,9 +6,10 @@ import { gameBoardMatrix } from "../types/game";
 type GameBoardProps = {
   board: gameBoardMatrix;
   handleTurn: (rowIndex: number, colIndex: number) => void;
+  isValid: boolean;
 };
 
-const GameBoard = ({ handleTurn, board }: GameBoardProps) => {
+const GameBoard = ({ handleTurn, board, isValid }: GameBoardProps) => {
   return (
     <ol id="game-board">
       {board.map((row, rowIndex) => (
@@ -20,6 +21,8 @@ const GameBoard = ({ handleTurn, board }: GameBoardProps) => {
                 onClick={() => {
                   handleTurn(rowIndex, colIndex);
                 }}
+                // !! turn value into bolean
+                disabled={!!symbol || !isValid}
               >
                 {symbol}
               </button>

--- a/src/components/GameOver.tsx
+++ b/src/components/GameOver.tsx
@@ -4,7 +4,6 @@ type gameOverProps = {
 };
 
 export default function GameOver({ winner, onRestart }: gameOverProps) {
-  console.log(winner);
   return (
     <div id="game-over">
       <h2>Game Over!</h2>

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -7,6 +7,7 @@ type PlayerProps = {
     e: React.ChangeEvent<HTMLInputElement>,
     symbol: "X" | "O"
   ) => void;
+  playerNameError: string | "";
   isActive: boolean;
 };
 
@@ -14,14 +15,17 @@ const Player = ({
   playerName,
   symbol,
   handleNameChange,
+  playerNameError,
   isActive,
 }: PlayerProps) => {
   const [isEditing, setIsEditing] = useState(false);
 
   const handleEdit = () => {
-    playerName.length > 0
-      ? setIsEditing((prev) => !prev)
-      : alert("player name cannot be blank");
+    if (!playerNameError) {
+      setIsEditing((prev) => !prev);
+    } else {
+      return;
+    }
   };
 
   const player = !isEditing ? (
@@ -32,21 +36,32 @@ const Player = ({
       autoFocus
       name={`${playerName}`}
       onChange={(e) => handleNameChange(e, symbol)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          handleEdit();
+        }
+      }}
     />
   );
 
   return (
     <li className={isActive ? "active" : ""}>
-      <span className="player">
-        {player}
-        <span className="player-symbol">{symbol}</span>
-        <button
-          data-testid={`playerNameButton-${symbol}`}
-          onClick={() => handleEdit()}
-        >
-          {isEditing ? "Save" : "Edit"}
-        </button>
-      </span>
+      <div className="player-wrapper">
+        <span className="player">
+          {player}
+          <span className="player-symbol">{symbol}</span>
+          <button
+            type="button"
+            data-testid={`playerNameButton-${symbol}`}
+            onClick={handleEdit}
+          >
+            {isEditing ? "Save" : "Edit"}
+          </button>
+        </span>
+        {playerNameError && (
+          <div className="playerError">{playerNameError}</div>
+        )}
+      </div>
     </li>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,11 @@
-@import url('https://fonts.googleapis.com/css2?family=Caprasimo&family=Roboto+Slab:wght@400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Caprasimo&family=Roboto+Slab:wght@400;700&display=swap");
 
 * {
   box-sizing: border-box;
 }
 
 html {
-  font-family: 'Roboto Slab', sans-serif;
+  font-family: "Roboto Slab", sans-serif;
   line-height: 1.5;
 
   color: #ebe7ef;
@@ -23,9 +23,12 @@ body {
       rgba(241, 210, 70, 0.98),
       rgba(250, 176, 103, 0.87)
     ),
-    url('bg-pattern-dark.png');
+    url("bg-pattern-dark.png");
   background-repeat: repeat;
-  background-size: 100% 100%, 30% 30%, 100% 100%;
+  background-size:
+    100% 100%,
+    30% 30%,
+    100% 100%;
   min-height: 110rem;
 }
 
@@ -41,7 +44,7 @@ header img {
 }
 
 h1 {
-  font-family: 'Caprasimo', cursive;
+  font-family: "Caprasimo", cursive;
   font-size: 3rem;
   margin: 0 auto 3rem auto;
   color: #3f3b00;
@@ -100,6 +103,9 @@ h1 {
   color: #f8ca31;
 }
 
+.player-wrapper {
+  padding: 0.25rem;
+}
 .player {
   border: 2px solid transparent;
   padding: 0.5rem;
@@ -137,7 +143,9 @@ h1 {
   font-size: 1rem;
   color: #e1dec7;
 }
-
+.playerError {
+  color: red;
+}
 ol {
   list-style: none;
   margin: 0;
@@ -153,7 +161,7 @@ ol {
   background: none;
   color: #f8c031;
   border: none;
-  font-family: 'Caprasimo', cursive;
+  font-family: "Caprasimo", cursive;
   font-size: 4rem;
   text-shadow: 0 0 12px rgba(0, 0, 0, 0.7);
   animation: pulse-text-size 2s infinite ease-out;
@@ -186,7 +194,7 @@ ol {
   color: #3f3b00;
   font-size: 5rem;
   cursor: pointer;
-  font-family: 'Caprasimo', cursive;
+  font-family: "Caprasimo", cursive;
   padding: 1rem;
 }
 
@@ -205,7 +213,7 @@ ol {
 }
 
 #game-over h2 {
-  font-family: 'Caprasimo', cursive;
+  font-family: "Caprasimo", cursive;
   font-size: 4rem;
   text-align: center;
   color: #fcd256;
@@ -228,7 +236,9 @@ ol {
   padding: 0.5rem 1rem;
   border-radius: 4px;
   cursor: pointer;
-  transition: all 0.2s, color 0.2s;
+  transition:
+    all 0.2s,
+    color 0.2s;
   box-shadow: 0 0 8px rgba(255, 187, 0, 0.4);
 }
 
@@ -265,7 +275,7 @@ ol {
 }
 
 #game-hints h2 {
-  font-family: 'Caprasimo', cursive;
+  font-family: "Caprasimo", cursive;
   font-size: 2rem;
   margin: 0;
 }

--- a/src/tests/__tests__/app.test.tsx
+++ b/src/tests/__tests__/app.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "../../App";
-import type { UserEvent } from "@testing-library/user-event";
 
 test("complete game flow: rename, play, win, draw, reset", async () => {
   const user = userEvent.setup();
@@ -10,12 +9,14 @@ test("complete game flow: rename, play, win, draw, reset", async () => {
   // -----------------------------
   // Step 1: Rename the players
   // -----------------------------
+
   await user.click(screen.getByTestId("playerNameButton-X"));
   let input = screen.getByRole("textbox");
   await user.clear(input);
+  await user.click(screen.getByRole("button", { name: "Save" }));
+  expect(screen.getByText("Player name can not be blank")).toBeInTheDocument();
   await user.type(input, "Alfie");
   await user.click(screen.getByRole("button", { name: "Save" }));
-
   await user.click(screen.getByTestId("playerNameButton-O"));
   input = screen.getByRole("textbox");
   await user.clear(input);

--- a/src/tests/__tests__/gameBoard.test.tsx
+++ b/src/tests/__tests__/gameBoard.test.tsx
@@ -11,7 +11,7 @@ describe("gameBoard component tests", () => {
     // turns bust be defined in each describe block to avoid all test using same values
     user = userEvent.setup();
     let mockBoard = deriveGameBoard([]);
-    render(<GameBoard board={mockBoard} handleTurn={mockHandleTurn} />);
+    render(<GameBoard board={mockBoard} handleTurn={mockHandleTurn} isValid />);
   });
 
   test("component renders with blank gameboard containing 9 buttons", () => {
@@ -36,7 +36,7 @@ describe("game board populate correctly", () => {
     let mockBoard = deriveGameBoard([
       { square: { rowIndex: 0, colIndex: 0 }, player: "X" },
     ]);
-    render(<GameBoard board={mockBoard} handleTurn={mockHandleTurn} />);
+    render(<GameBoard board={mockBoard} handleTurn={mockHandleTurn} isValid />);
   });
   test("gameboard populates with correct symbol", () => {
     const buttons = screen.getAllByRole("button");

--- a/src/tests/__tests__/player.test.tsx
+++ b/src/tests/__tests__/player.test.tsx
@@ -15,6 +15,7 @@ const componentUnderTest = (
     playerName={mockPlayers.X}
     symbol="X"
     handleNameChange={mockNameChange}
+    playerNameError=""
     isActive
   />
 );
@@ -56,6 +57,7 @@ describe("player element class", () => {
         playerName={mockPlayers.X}
         symbol="X"
         handleNameChange={mockNameChange}
+        playerNameError=""
         isActive={true}
       />
     );
@@ -68,6 +70,7 @@ describe("player element class", () => {
         playerName={mockPlayers.O}
         symbol="O"
         handleNameChange={mockNameChange}
+        playerNameError=""
         isActive={false}
       />
     );
@@ -77,36 +80,40 @@ describe("player element class", () => {
 });
 // wrapper used to simulate state changes
 describe("Player input interactions (with wrapper)", async () => {
-  const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
-
   beforeEach(() => {
     user = userEvent.setup();
-    alertMock;
     render(<PlayerWrapper />);
   });
 
-  afterEach(() => {
-    alertMock.mockRestore();
-  });
   test("player input cannot be left blank", async () => {
-    const editButton = screen.getByRole("button", { name: "Edit" });
-    await user.click(editButton);
+    const editButton = screen.getAllByRole("button", { name: "Edit" });
+    await user.click(editButton[0]);
     const playerInput = screen.getByRole("textbox");
     await user.clear(playerInput);
     expect(playerInput).toHaveValue("");
     const saveButton = screen.getByRole("button", { name: "Save" });
     await user.click(saveButton);
-    expect(alertMock).toHaveBeenCalled();
+    expect(
+      screen.getByText("Player name can not be blank")
+    ).toBeInTheDocument();
+  });
+  test("player O cannot use same name as player X", async () => {
+    const editButtons = screen.getAllByRole("button", { name: "Edit" });
+    await user.click(editButtons[1]);
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "Player 1");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.getByText("Player name must be unique")).toBeInTheDocument();
   });
   test("player name is editable and saves", async () => {
-    const editButton = screen.getByRole("button", { name: "Edit" });
-    await user.click(editButton);
+    const editButton = screen.getAllByRole("button", { name: "Edit" });
+    await user.click(editButton[0]);
     const playerInput = screen.getByRole("textbox");
     await user.clear(playerInput);
     await user.type(playerInput, "test");
     const saveButton = screen.getByRole("button", { name: "Save" });
     await user.click(saveButton);
-    expect(alertMock).not.toHaveBeenCalled();
     const newPlayerName = screen.getByText("test");
     expect(newPlayerName).toBeInTheDocument();
   });

--- a/src/tests/testWrappers/PlayerWrapper.tsx
+++ b/src/tests/testWrappers/PlayerWrapper.tsx
@@ -3,22 +3,49 @@ import Player from "../../components/Player";
 
 const PlayerWrapper = () => {
   const [players, setPlayers] = useState({ X: "Player 1", O: "Player 2" });
+  const [playerNameError, setPlayersNameError] = useState({ X: "", O: "" });
 
   const handleNameChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     symbol: "X" | "O"
   ) => {
-    const value = e.target.value;
-    setPlayers((prev) => ({ ...prev, [symbol]: value }));
+    const newInput = e.target.value;
+    const trimmed = newInput.trim();
+    const otherSymbol = symbol === "X" ? "O" : "X";
+
+    setPlayers((prev) => ({ ...prev, [symbol]: newInput }));
+    if (!trimmed) {
+      setPlayersNameError((prev) => ({
+        ...prev,
+        [symbol]: "Player name can not be blank",
+      }));
+    } else if (trimmed === players[otherSymbol].trim()) {
+      setPlayersNameError((prev) => ({
+        ...prev,
+        [symbol]: "Player name must be unique",
+      }));
+    } else {
+      setPlayersNameError((prev) => ({ ...prev, [symbol]: "" }));
+    }
   };
 
   return (
-    <Player
-      playerName={players.X}
-      symbol="X"
-      handleNameChange={handleNameChange}
-      isActive
-    />
+    <>
+      <Player
+        playerName={players.X}
+        symbol="X"
+        handleNameChange={handleNameChange}
+        isActive
+        playerNameError={playerNameError.X}
+      />
+      <Player
+        playerName={players.O}
+        symbol="O"
+        handleNameChange={handleNameChange}
+        isActive={false}
+        playerNameError={playerNameError.O}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
- Added validation to ensure player names are not blank
- Enforced uniqueness between player names
- Disabled board buttons if any validation errors exist
- Implemented saving player name on Enter key press
- Updated tests to cover these changes